### PR TITLE
Correct Composition.attester.mode sent as array (0..1 field in R4)

### DIFF
--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -440,7 +440,7 @@ module Crucible
         when FHIR::CommunicationRequest
           resource.payload = nil
         when FHIR::Composition
-          resource.attester.each {|a| a.mode = ['professional']}
+          resource.attester.each {|a| a.mode = 'professional'}
           resource.section.each do |section|
             section.emptyReason = nil
             section.section.each do |sub|


### PR DESCRIPTION
In FHIR R4, Composition.attester.mode is 0..1 (scalar code). In STU3 and DSTU2 it's 0..* (array). Apply invariant sets a scalar string for R4. STU3/DSTU2 keep the array form which is correct for those versions.